### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "laravel/prompts": "^0.3.5",
         "phpdocumentor/reflection-docblock": "^5.6",
         "roave/better-reflection": "^6.57",


### PR DESCRIPTION
## Summary

Adds `^13.0` to the `illuminate/contracts` constraint to support Laravel 13.

Laravel 13 was released and ships `illuminate/contracts` v13.x. The package works without any code changes — just the version constraint needed updating.

## Changes

- `composer.json`: `illuminate/contracts` constraint updated from `^10.0||^11.0||^12.0` to `^10.0||^11.0||^12.0||^13.0`

## Testing

Tested in a Laravel 13.2.0 application with [clinically/laravel-companion-demo](https://github.com/clinically-au/laravel-companion-demo) which depends on this package. All model discovery, route introspection, and reflection features work correctly.