### PR TITLE
fix: correct facade alias in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
                 "Mateffy\\Introspect\\LaravelIntrospectServiceProvider"
             ],
             "aliases": {
-                "Introspect": "Introspect"
+                "Introspect": "Mateffy\\Introspect\\Facades\\Introspect"
             }
         }
     },


### PR DESCRIPTION
Fixes #9 - The alias was self-referential pointing to non-existent class. Now points to correct namespace Mateffy\Introspect\Facades\Introspect