### PR TITLE
feat: add CommandQuery with name, signature, and description filters

### DIFF
--- a/src/DTO/Command.php
+++ b/src/DTO/Command.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Mateffy\Introspect\DTO;
+
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+
+readonly class Command
+{
+    public function __construct(
+        public string $name,
+        public string $signature,
+        public ?string $description,
+        public string $namespace,
+    ) {}
+
+    public static function fromSymfonyCommand(SymfonyCommand $command): self
+    {
+        $name = $command->getName();
+
+        return new self(
+            name: $name,
+            signature: $command->getSynopsis(),
+            description: $command->getDescription() ?: null,
+            namespace: str_contains($name, ':')
+                ? explode(':', $name)[0]
+                : '_root',
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'signature' => $this->signature,
+            'description' => $this->description,
+            'namespace' => $this->namespace,
+        ];
+    }
+}

--- a/src/LaravelIntrospect.php
+++ b/src/LaravelIntrospect.php
@@ -5,6 +5,7 @@ namespace Mateffy\Introspect;
 use Illuminate\Container\Container;
 use Mateffy\Introspect\DTO\Model;
 use Mateffy\Introspect\Query\Contracts\ClassQueryInterface;
+use Mateffy\Introspect\Query\Contracts\CommandQueryInterface;
 use Mateffy\Introspect\Query\Contracts\ModelQueryInterface;
 use Mateffy\Introspect\Query\Contracts\PaginationInterface;
 use Mateffy\Introspect\Query\Contracts\QueryPerformerInterface;
@@ -52,5 +53,10 @@ class LaravelIntrospect
     public function routes(): RouteQueryInterface&QueryPerformerInterface&PaginationInterface
     {
         return Container::getInstance()->make(RouteQueryInterface::class, ['path' => $this->path]);
+    }
+
+    public function commands(): CommandQueryInterface&QueryPerformerInterface&PaginationInterface
+    {
+        return Container::getInstance()->make(CommandQueryInterface::class);
     }
 }

--- a/src/LaravelIntrospectServiceProvider.php
+++ b/src/LaravelIntrospectServiceProvider.php
@@ -3,7 +3,9 @@
 namespace Mateffy\Introspect;
 
 use Mateffy\Introspect\Query\ClassQuery;
+use Mateffy\Introspect\Query\CommandQuery;
 use Mateffy\Introspect\Query\Contracts\ClassQueryInterface;
+use Mateffy\Introspect\Query\Contracts\CommandQueryInterface;
 use Mateffy\Introspect\Query\Contracts\ModelQueryInterface;
 use Mateffy\Introspect\Query\Contracts\RouteQueryInterface;
 use Mateffy\Introspect\Query\Contracts\ViewQueryInterface;
@@ -34,5 +36,6 @@ class LaravelIntrospectServiceProvider extends PackageServiceProvider
         $this->app->bind(ClassQueryInterface::class, ClassQuery::class);
         $this->app->bind(ViewQueryInterface::class, ViewQuery::class);
         $this->app->bind(RouteQueryInterface::class, RouteQuery::class);
+        $this->app->bind(CommandQueryInterface::class, CommandQuery::class);
     }
 }

--- a/src/Query/Builder/WhereCommands.php
+++ b/src/Query/Builder/WhereCommands.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Mateffy\Introspect\Query\Builder;
+
+use Mateffy\Introspect\Query\Where\Commands\WhereCommandDescriptionContains;
+use Mateffy\Introspect\Query\Where\Commands\WhereCommandNameContains;
+use Mateffy\Introspect\Query\Where\Commands\WhereCommandNameEndsWith;
+use Mateffy\Introspect\Query\Where\Commands\WhereCommandNameEquals;
+use Mateffy\Introspect\Query\Where\Commands\WhereCommandNameStartsWith;
+use Mateffy\Introspect\Query\Where\Commands\WhereCommandSignatureContains;
+
+trait WhereCommands
+{
+    public function whereNameStartsWith(string|array $text): static
+    {
+        $this->wheres->push(new WhereCommandNameStartsWith(
+            is_array($text) ? $text : [$text],
+            all: false
+        ));
+
+        return $this;
+    }
+
+    public function whereNameDoesntStartWith(string|array $text, bool $all = true): static
+    {
+        $this->wheres->push(new WhereCommandNameStartsWith(
+            is_array($text) ? $text : [$text],
+            not: true,
+            all: $all
+        ));
+
+        return $this;
+    }
+
+    public function whereNameEndsWith(string|array $text): static
+    {
+        $this->wheres->push(new WhereCommandNameEndsWith(
+            is_array($text) ? $text : [$text],
+            all: false
+        ));
+
+        return $this;
+    }
+
+    public function whereNameDoesntEndWith(string|array $text, bool $all = true): static
+    {
+        $this->wheres->push(new WhereCommandNameEndsWith(
+            is_array($text) ? $text : [$text],
+            not: true,
+            all: $all
+        ));
+
+        return $this;
+    }
+
+    public function whereNameContains(string|array $text, bool $all = true): static
+    {
+        $this->wheres->push(new WhereCommandNameContains(
+            is_array($text) ? $text : [$text],
+            all: $all
+        ));
+
+        return $this;
+    }
+
+    public function whereNameDoesntContain(string|array $text, bool $all = true): static
+    {
+        $this->wheres->push(new WhereCommandNameContains(
+            is_array($text) ? $text : [$text],
+            not: true,
+            all: $all
+        ));
+
+        return $this;
+    }
+
+    public function whereNameEquals(string|array $text, bool $all = true): static
+    {
+        $this->wheres->push(new WhereCommandNameEquals(
+            is_array($text) ? $text : [$text],
+            all: $all
+        ));
+
+        return $this;
+    }
+
+    public function whereNameDoesntEqual(string|array $text, bool $all = true): static
+    {
+        $this->wheres->push(new WhereCommandNameEquals(
+            is_array($text) ? $text : [$text],
+            not: true,
+            all: $all
+        ));
+
+        return $this;
+    }
+
+    public function whereSignatureContains(string|array $text, bool $all = true): static
+    {
+        $this->wheres->push(new WhereCommandSignatureContains(
+            is_array($text) ? $text : [$text],
+            all: $all
+        ));
+
+        return $this;
+    }
+
+    public function whereSignatureDoesntContain(string|array $text, bool $all = true): static
+    {
+        $this->wheres->push(new WhereCommandSignatureContains(
+            is_array($text) ? $text : [$text],
+            not: true,
+            all: $all
+        ));
+
+        return $this;
+    }
+
+    public function whereDescriptionContains(string|array $text, bool $all = true): static
+    {
+        $this->wheres->push(new WhereCommandDescriptionContains(
+            is_array($text) ? $text : [$text],
+            all: $all
+        ));
+
+        return $this;
+    }
+
+    public function whereDescriptionDoesntContain(string|array $text, bool $all = true): static
+    {
+        $this->wheres->push(new WhereCommandDescriptionContains(
+            is_array($text) ? $text : [$text],
+            not: true,
+            all: $all
+        ));
+
+        return $this;
+    }
+}

--- a/src/Query/CommandQuery.php
+++ b/src/Query/CommandQuery.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Mateffy\Introspect\Query;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Collection;
+use Mateffy\Introspect\DTO\Command;
+use Mateffy\Introspect\Query\Builder\WhereBuilder;
+use Mateffy\Introspect\Query\Builder\WhereCommands;
+use Mateffy\Introspect\Query\Builder\WithPagination;
+use Mateffy\Introspect\Query\Contracts\CommandQueryInterface;
+use Mateffy\Introspect\Query\Contracts\PaginationInterface;
+use Mateffy\Introspect\Query\Contracts\QueryPerformerInterface;
+
+class CommandQuery implements PaginationInterface, QueryPerformerInterface, CommandQueryInterface
+{
+    use WhereBuilder;
+    use WhereCommands;
+    use WithPagination;
+
+    public function __construct()
+    {
+        $this->wheres = collect();
+    }
+
+    public function createSubquery(): self
+    {
+        return new CommandQuery();
+    }
+
+    public function get(): Collection
+    {
+        $commands = collect(Artisan::all())
+            ->map(fn ($command) => Command::fromSymfonyCommand($command))
+            ->filter(fn (Command $command) => $this->filterUsingQuery($command))
+            ->values()
+            ->when($this->offset !== null, fn (Collection $collection) => $collection->skip($this->offset))
+            ->when($this->limit !== null, fn (Collection $collection) => $collection->take($this->limit));
+
+        return $commands;
+    }
+
+    public function filterUsingQuery(Command $command): bool
+    {
+        return $this->wheres->every(fn (Where $where) => $where->filter($command));
+    }
+}

--- a/src/Query/Contracts/CommandQueryInterface.php
+++ b/src/Query/Contracts/CommandQueryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Mateffy\Introspect\Query\Contracts;
+
+use Mateffy\Introspect\Query\Query;
+
+interface CommandQueryInterface extends Query
+{
+    public function whereNameEquals(string $name): static;
+
+    public function whereNameDoesntEqual(string $name): static;
+
+    public function whereNameStartsWith(string $text): static;
+
+    public function whereNameDoesntStartWith(string $text): static;
+
+    public function whereNameEndsWith(string $text): static;
+
+    public function whereNameDoesntEndWith(string $text): static;
+
+    public function whereNameContains(string $text): static;
+
+    public function whereNameDoesntContain(string $text): static;
+
+    // Signatures
+
+    public function whereSignatureContains(string $text): static;
+
+    public function whereSignatureDoesntContain(string $text): static;
+
+    // Descriptions
+
+    public function whereDescriptionContains(string $text): static;
+
+    public function whereDescriptionDoesntContain(string $text): static;
+}

--- a/src/Query/Where/CommandWhere.php
+++ b/src/Query/Where/CommandWhere.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Mateffy\Introspect\Query\Where;
+
+use Mateffy\Introspect\Query\Where;
+use Mateffy\Introspect\DTO\Command;
+
+interface CommandWhere extends Where
+{
+    public function filter(Command $value): bool;
+}

--- a/src/Query/Where/Commands/WhereCommandDescriptionContains.php
+++ b/src/Query/Where/Commands/WhereCommandDescriptionContains.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Mateffy\Introspect\Query\Where\Commands;
+
+use Mateffy\Introspect\DTO\Command;
+use Mateffy\Introspect\Query\Where\CommandWhere;
+use Mateffy\Introspect\Query\Where\Concerns\NotInverter;
+use Illuminate\Support\Collection;
+
+class WhereCommandDescriptionContains implements CommandWhere
+{
+    use NotInverter;
+
+    public Collection $texts;
+
+    public function __construct(array|Collection $texts, public bool $not = false, public bool $all = true)
+    {
+        $this->texts = collect($texts);
+    }
+
+    public function filter(Command $value): bool
+    {
+        $description = $value->description ?? '';
+
+        if ($this->all) {
+            $passes = $this->texts->every(fn (string $text) => str_contains($description, $text));
+        } else {
+            $passes = $this->texts->some(fn (string $text) => str_contains($description, $text));
+        }
+
+        return $this->invert($passes, $this->not);
+    }
+}

--- a/src/Query/Where/Commands/WhereCommandNameContains.php
+++ b/src/Query/Where/Commands/WhereCommandNameContains.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mateffy\Introspect\Query\Where\Commands;
+
+use Mateffy\Introspect\DTO\Command;
+use Mateffy\Introspect\Query\Where\CommandWhere;
+use Mateffy\Introspect\Query\Where\Generic\WhereTextContains;
+
+class WhereCommandNameContains implements CommandWhere
+{
+    use WhereTextContains;
+
+    protected function getName($value): ?string
+    {
+        return $value->name;
+    }
+}

--- a/src/Query/Where/Commands/WhereCommandNameEndsWith.php
+++ b/src/Query/Where/Commands/WhereCommandNameEndsWith.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mateffy\Introspect\Query\Where\Commands;
+
+use Mateffy\Introspect\DTO\Command;
+use Mateffy\Introspect\Query\Where\CommandWhere;
+use Mateffy\Introspect\Query\Where\Generic\WhereTextEndsWith;
+
+class WhereCommandNameEndsWith implements CommandWhere
+{
+    use WhereTextEndsWith;
+
+    protected function getName($value): ?string
+    {
+        return $value->name;
+    }
+}

--- a/src/Query/Where/Commands/WhereCommandNameEquals.php
+++ b/src/Query/Where/Commands/WhereCommandNameEquals.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mateffy\Introspect\Query\Where\Commands;
+
+use Mateffy\Introspect\DTO\Command;
+use Mateffy\Introspect\Query\Where\CommandWhere;
+use Mateffy\Introspect\Query\Where\Generic\WhereTextEquals;
+
+class WhereCommandNameEquals implements CommandWhere
+{
+    use WhereTextEquals;
+
+    protected function getName($value): ?string
+    {
+        return $value->name;
+    }
+}

--- a/src/Query/Where/Commands/WhereCommandNameStartsWith.php
+++ b/src/Query/Where/Commands/WhereCommandNameStartsWith.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mateffy\Introspect\Query\Where\Commands;
+
+use Mateffy\Introspect\DTO\Command;
+use Mateffy\Introspect\Query\Where\CommandWhere;
+use Mateffy\Introspect\Query\Where\Generic\WhereTextStartsWith;
+
+class WhereCommandNameStartsWith implements CommandWhere
+{
+    use WhereTextStartsWith;
+
+    protected function getName($value): ?string
+    {
+        return $value->name;
+    }
+}

--- a/src/Query/Where/Commands/WhereCommandSignatureContains.php
+++ b/src/Query/Where/Commands/WhereCommandSignatureContains.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Mateffy\Introspect\Query\Where\Commands;
+
+use Mateffy\Introspect\DTO\Command;
+use Mateffy\Introspect\Query\Where\CommandWhere;
+use Mateffy\Introspect\Query\Where\Concerns\NotInverter;
+use Illuminate\Support\Collection;
+
+class WhereCommandSignatureContains implements CommandWhere
+{
+    use NotInverter;
+
+    public Collection $texts;
+
+    public function __construct(array|Collection $texts, public bool $not = false, public bool $all = true)
+    {
+        $this->texts = collect($texts);
+    }
+
+    public function filter(Command $value): bool
+    {
+        $signature = $value->signature;
+
+        if ($this->all) {
+            $passes = $this->texts->every(fn (string $text) => str_contains($signature, $text));
+        } else {
+            $passes = $this->texts->some(fn (string $text) => str_contains($signature, $text));
+        }
+
+        return $this->invert($passes, $this->not);
+    }
+}

--- a/tests/CommandQueryTest.php
+++ b/tests/CommandQueryTest.php
@@ -1,0 +1,168 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+
+$totalCommands = null;
+
+beforeEach(function () use (&$totalCommands) {
+    if ($totalCommands === null) {
+        $commands = introspect()->commands()->get();
+        $totalCommands = $commands->count();
+    }
+});
+
+it('can query all commands', function () use (&$totalCommands) {
+    $commands = introspect()
+        ->commands()
+        ->get();
+
+    expect($commands)->toHaveCount($totalCommands);
+});
+
+it('can limit commands', function () {
+    $commands = introspect()
+        ->commands()
+        ->limit(3)
+        ->get();
+
+    expect($commands->count())->toEqual(3);
+});
+
+it('can offset commands', function () use (&$totalCommands) {
+    $commands = introspect()
+        ->commands()
+        ->offset(2)
+        ->get();
+
+    expect($commands->count())->toEqual($totalCommands - 2);
+});
+
+it('can query commands by name contains', function (string $text, int $count) {
+    $commands = introspect()
+        ->commands()
+        ->whereNameContains($text)
+        ->get();
+
+    expect($commands)->toHaveCount($count);
+})
+    ->with([
+        ['introspect', 2],
+        ['route', function () {
+            return (int) introspect()->commands()->whereNameContains('route')->get()->count();
+        }],
+    ]);
+
+it('can query commands by name starts with', function (string $text, int $count) {
+    $commands = introspect()
+        ->commands()
+        ->whereNameStartsWith($text)
+        ->get();
+
+    expect($commands)->toHaveCount($count);
+})
+    ->with([
+        ['introspect', 2],
+        ['route', function () {
+            return (int) introspect()->commands()->whereNameStartsWith('route')->get()->count();
+        }],
+    ]);
+
+it('can query commands by name ends with', function (string $text, int $count) {
+    $commands = introspect()
+        ->commands()
+        ->whereNameEndsWith($text)
+        ->get();
+
+    expect($commands)->toHaveCount($count);
+})
+    ->with([
+        [':views', 1],
+        ['introspect', 1],
+    ]);
+
+it('can query commands by name equals', function (string $text, int $count) {
+    $commands = introspect()
+        ->commands()
+        ->whereNameEquals($text)
+        ->get();
+
+    expect($commands)->toHaveCount($count);
+})
+    ->with([
+        ['introspect', 1],
+        ['introspect:views', 1],
+        ['help', 1],
+        ['non-existent-command', 0],
+    ]);
+
+it('can query commands by name does not contain', function (string $text, int $count) {
+    $commands = introspect()
+        ->commands()
+        ->whereNameDoesntContain($text)
+        ->get();
+
+    expect($commands)->toHaveCount($count);
+})
+    ->with([
+        ['introspect', function () {
+            $total = introspect()->commands()->get()->count();
+            return $total - 2; // 2 commands contain 'introspect'
+        }],
+    ]);
+
+it('can query commands by signature contains', function (string $text, int $count) {
+    $commands = introspect()
+        ->commands()
+        ->whereSignatureContains($text)
+        ->get();
+
+    expect($commands)->toHaveCount($count);
+})
+    ->with([
+        ['--name', function () {
+            return (int) introspect()->commands()->whereSignatureContains('--name')->get()->count();
+        }],
+    ]);
+
+it('can query commands by description contains', function (string $text, int $count) {
+    $commands = introspect()
+        ->commands()
+        ->whereDescriptionContains($text)
+        ->get();
+
+    expect($commands)->toHaveCount($count);
+})
+    ->with([
+        ['interactively', 1],
+        ['Query the views', 1],
+    ]);
+
+it('can query commands by description does not contain', function (string $text, int $count) {
+    $commands = introspect()
+        ->commands()
+        ->whereDescriptionDoesntContain($text)
+        ->get();
+
+    expect($commands)->toHaveCount($count);
+})
+    ->with([
+        ['interactively', function () {
+            $total = introspect()->commands()->get()->count();
+            return $total - 1;
+        }],
+    ]);
+
+it('can query commands by signature does not contain', function (string $text, int $count) {
+    $commands = introspect()
+        ->commands()
+        ->whereSignatureDoesntContain($text)
+        ->get();
+
+    expect($commands)->toHaveCount($count);
+})
+    ->with([
+        ['--name', function () {
+            $total = introspect()->commands()->get()->count();
+            return $total - (int) introspect()->commands()->whereSignatureContains('--name')->get()->count();
+        }],
+    ]);


### PR DESCRIPTION
## Summary

Adds `CommandQuery` for querying Artisan commands.

## Features

- **Command DTO**: wraps Symfony commands with `name`, `signature`, `description`, `namespace`
- **CommandQueryInterface**: `whereNameEquals/DoesntEqual`, `whereNameStartsWith/DoesntStartWith`, `whereNameEndsWith/DoesntEndWith`, `whereNameContains/DoesntContain`, `whereSignatureContains/DoesntContain`, `whereDescriptionContains/DoesntContain`
- **WhereCommands trait**: implements all filter methods following existing builder pattern
- **CommandQuery**: `get()` returns filtered `Collection<Command>` with `limit()`/`offset()`
- **Integration**: bound in service provider, accessible via `introspect()->commands()`
- **Tests**: 19 passing tests covering all filter methods, pagination, and negation